### PR TITLE
Made a way to switch between drive train types

### DIFF
--- a/commands/arcadeDrive.py
+++ b/commands/arcadeDrive.py
@@ -6,7 +6,7 @@ class ArcadeDrive(commands2.CommandBase):
     '''
     Command for converting joystick input to drive train output
     '''
-    def __init__(self, speed: Callable[[], float], mix: Callable[[], float], driveTrain):
+    def __init__(self, mix: Callable[[], float], speed: Callable[[], float], driveTrain):
         '''
         Takes a left, right callerable to get tank drive controls
         Takes driveTrain on which to operate. Requires drive train with left, right drive call.
@@ -25,11 +25,8 @@ class ArcadeDrive(commands2.CommandBase):
         Called repeatably when this command is scheduled to run.
         '''
         speed = self.speed()
-        mix = self.mix()
-        left = speed * mix
-        right = speed * -mix
-        print(f"l {left}, r {right}")
-        self.driveTrain.drive(left, right)
+        rotation = self.mix()
+        self.driveTrain.arcadeDrive(-speed, -rotation)
 
     def end(self, interrupted: bool) -> None:
         '''

--- a/commands/arcadeDrive.py
+++ b/commands/arcadeDrive.py
@@ -26,7 +26,7 @@ class ArcadeDrive(commands2.CommandBase):
         '''
         speed = self.speed()
         rotation = self.mix()
-        self.driveTrain.arcadeDrive(-speed, -rotation)
+        self.driveTrain.arcadeDrive(speed, rotation)
 
     def end(self, interrupted: bool) -> None:
         '''

--- a/robots/greenBot.py
+++ b/robots/greenBot.py
@@ -7,52 +7,79 @@ from commands.tankDrive import TankDrive
 from commands.arcadeDrive import ArcadeDrive
 import wpimath.filter
 import wpimath
+import typing
 
 import enum
+from enum import Enum, auto
 
 class GreenBot(commands2.TimedCommandRobot):
     config_name = "GreenBot"
 
+
+    InputCommand: typing.Optional[commands2.Command] = None
     class DrivetrainMode(enum.Enum):
         ARCADE = enum.auto()
         TANK = enum.auto()
 
+    controlMode = DrivetrainMode.TANK
+    controlModes = {"Tank": DrivetrainMode.TANK, "Arcade": DrivetrainMode.ARCADE}
+
+    def selectInput(self) -> DrivetrainMode:
+        self.controlMode = self.chooser.getSelected()
+        print("Mode =" + str(self.controlMode))
+        return self.controlMode
 
     def __init__(self, period: float = 0.02) -> None:
+        """
+        Creates the greenbot motors and gets the input from an xbox controller
+        """
         super().__init__(period)
 
-        #create the greenbot motors
         motors = {}
         motors['right'] = ctre.WPI_TalonFX(30)
         motors['rightF'] = ctre.WPI_TalonFX(31)
         motors['left'] = ctre.WPI_TalonFX(20)
         motors['leftF'] = ctre.WPI_TalonFX(21)
 
-        rightM = wpilib.MotorControllerGroup(motors['right'], motors['rightF'])
-        leftM = wpilib.MotorControllerGroup(motors['left'], motors['leftF'])
+        self.rightM = wpilib.MotorControllerGroup(motors['right'], motors['rightF'])
+        self.leftM = wpilib.MotorControllerGroup(motors['left'], motors['leftF'])
 
-        self.driveTrain = Drivetrain(rightM, leftM, motors['left'], motors['right'], navx.AHRS.create_i2c())
-        self.tankDrive = TankDrive(getStick(wpilib.XboxController.Axis.kRightY, True),
+
+        self.driveTrain = Drivetrain(self.rightM, self.leftM, motors['left'], motors['right'], navx.AHRS.create_i2c())
+        self.tankDrive = TankDrive(getStick(wpilib.XboxController.Axis.kRightY, False),
                                    getStick(wpilib.XboxController.Axis.kLeftY, False),
                                    self.driveTrain)
         self.arcadeDrive = ArcadeDrive(getStick(wpilib.XboxController.Axis.kLeftY, True),
                                    getStick(wpilib.XboxController.Axis.kRightX, False),
                                    self.driveTrain)
 
-        #self.driveModeSelect = commands2.SelectCommand(
-        #    self.DrivetrainMode.TANK
-        #)
+        self.chooser = wpilib.SendableChooser()
+
+        for key, item in self.controlModes.items():
+            if item == self.controlMode:
+                self.chooser.setDefaultOption(key, self.controlMode)
+            self.chooser.addOption(key, item)
+
+        wpilib.SmartDashboard.putData("Control Mode", self.chooser)
 
     def teleopInit(self) -> None:
-        self.driveTrain.setDefaultCommand(self.tankDrive)
+        #TODO create a way to switch between drivetrain types
+        self.controlMode = self.chooser.getSelected()
+        print(str(self.controlMode))
 
+        if self.controlMode == self.DrivetrainMode.TANK:
+            self.driveTrain.setDefaultCommand(self.tankDrive)
+            self.rightM.setInverted(True)
+        elif self.controlMode == self.DrivetrainMode.ARCADE:
+            self.driveTrain.setDefaultCommand(self.arcadeDrive)
 
-
-
+    class tank(commands2.CommandBase):
+        def __init__(self) -> None:
+            super().__init__()
+            commands2.PrintCommand("Command Tank was selected")
 
 #TODO move to a better way, demo purposes
 def getStick(axis: wpilib.XboxController.Axis, invert: bool = False):
     sign = -1.0 if invert else 1.0
     slew = wpimath.filter.SlewRateLimiter(3)
     return lambda: slew.calculate(wpimath.applyDeadband(sign * wpilib.XboxController(0).getRawAxis(axis), 0.1))
-

--- a/robots/greenBot.py
+++ b/robots/greenBot.py
@@ -10,7 +10,6 @@ import wpimath
 import typing
 
 import enum
-from enum import Enum, auto
 
 class GreenBot(commands2.TimedCommandRobot):
     config_name = "GreenBot"

--- a/subsystems/drivetrains/westcoast.py
+++ b/subsystems/drivetrains/westcoast.py
@@ -53,6 +53,12 @@ class Westcoast(commands2.SubsystemBase):
         '''
         self.driveTrain.tankDrive(left, right)
 
+    def arcadeDrive(self, speed: float, turn: float) -> None:
+        '''
+        Sets the left and right speed of robot
+        '''
+        self.driveTrain.arcadeDrive(speed, turn)
+
     def getHeading(self) -> float:
         '''
         Returns the heading if known. If not returns NaN


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issue(s)
This made a way to switch between tank drive and arcade drive using the smart dashboard solving Issue #40 

## Steps to Test
[ Describe how to run your AUTOMATED TESTS and any manual tests that may be need to prove your fix/feature REMOVE THIS WHEN DONE]
1. Run the code in the sim and click networktable, then smartdashboard to see a pop up that says controlmode. Using this you can see the motors get the output associated with the drive type during the teleop mode.
2. This has been run on greenbot in a very similar manner to the step above.

## Changelog
We need a way to switch between the different drive types.

## Why?
I am making this change so driveteam has a simple and easy way to switch how they are driving.




