### PR TITLE
Makefile updated to fix pip setuptools install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CWD=${CURDIR}
 
 ifeq ($(OS), Windows_NT)
 VENV=.venv_windows
-PYTHON=py
+PYTHON=python
 VENVBIN=./${VENV}/Scripts
 else ifneq ("$(wildcard /.dockerenv)","")
 VENV=.venv_docker
@@ -41,7 +41,7 @@ coverage: setup_${VENV} test
 	${VENVBIN}/${PYTHON} robot.py coverage test
 
 setup_${VENV}: ${VENV}
-	${VENVBIN}/pip install --upgrade pip setuptools
+	${VENVBIN}/${PYTHON} -m pip install --upgrade pip setuptools
 	${VENVBIN}/pip install --pre -r ${CWD}/requirements.txt
 	$(file > setup_${VENV})
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Associated Issue(s)
Issue: #52 

## Changelog

The makefile prior to this change did not properly upgrade `pip setuptools` when setting up the windows virtual environment, causing the make to fail. 
This version upgrades `pip setuptools` through python instead of directly through pip.

## What?

~~${VENVBIN}/pip install --upgrade pip setuptools~~
*${VENVBIN}/${PYTHON} -m pip install --upgrade pip setuptools*

## Why?

Allows makefile to work for windows environment




